### PR TITLE
Fix running in custom container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
+
     - name: Add Azure secrets to environment
       shell: bash
       env:
@@ -21,6 +22,8 @@ runs:
         ESCAPE_VALUES: ${{ inputs.escape-values }}
       run: |
         curl -sSL https://install.python-poetry.org | python3 -
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        export PATH="$HOME/.local/bin:$PATH"
         cd $GITHUB_ACTION_PATH
         poetry install --no-root
         poetry run python $GITHUB_ACTION_PATH/extract_azure_keyvault.py --branch ${{ inputs.config }} --root ${GITHUB_WORKSPACE}/parameters


### PR DESCRIPTION
# Background

This action fails when run in a custom container. Actions jobs may run in a container when specified as follows:

```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    container:
      image: image-name
```

The action uses the `github.action_path` context property, which [does not contain the action path when run in a container](https://github.com/actions/runner/issues/716).

In addition, the action relies on `~/.local/bin` being in the `PATH` to find the `poetry` binary. This is the case on the host, but not in the container.

# Changes

- Use `$GITHUB_ACTION_PATH` instead of `github.action_path` to find the action path.
- Add `$HOME/.local/bin` to the `PATH`, so `poetry` is findable.
